### PR TITLE
Fragment the wave shader into optional parts

### DIFF
--- a/game/wave_shader.rpy
+++ b/game/wave_shader.rpy
@@ -43,17 +43,14 @@
 
 init -1 python:
     from renpy.uguu import GL_CLAMP_TO_EDGE, GL_MIRRORED_REPEAT, GL_REPEAT
-    renpy.register_shader("watt.wave", variables="""
+    wave_variables="""
         uniform float u_shader_time;
         uniform vec2 u_wave_period;
         uniform vec2 u_wave_amp;
         uniform vec2 u_wave_speed;
-        uniform float u_direction;
         uniform vec2 u_damp;
-        uniform float u_double;
         uniform vec3 u_double_params_x;
         uniform vec3 u_double_params_y;
-        uniform float u_melt;
         uniform vec3 u_melt_params_x;
         uniform vec3 u_melt_params_y;
 
@@ -61,52 +58,75 @@ init -1 python:
         uniform vec2 u_model_size;
         attribute vec2 a_tex_coord;
         varying vec2 v_coords;
-    """, vertex_200 = """
+    """
+    renpy.register_shader("watt.wave.common", variables=wave_variables,
+        vertex_200="""
         v_coords = a_tex_coord;
     """, fragment_300="""
-        vec2 new_pos;
-        vec2 wave_offset = vec2(0.0, 0.0);
-        vec2 melt_offset = vec2(0.0, 0.0);
-        vec2 double_offset = vec2(0.0, 0.0);
-        vec2 double_pos = vec2(0.0, 0.0);
-        vec2 damp = vec2(1.0, 1.0);
+        vec2 wave_offset;
+        vec2 melt_offset;
+        vec2 double_offset;
+        vec2 damp;
         vec4 new_color;
-        vec4 double_color;
 
-        if (u_damp.x >= 0.0 && u_damp.x != 1.0) {damp.x = pow(u_damp.x, v_coords.y * u_model_size.y);}
-        else if (u_damp.x < 0.0) {damp.x = pow((-1.0 * u_damp.x), (1.0 - v_coords.y) * u_model_size.y);}
-        if (u_damp.y >= 0.0 && u_damp.y != 1.0) {damp.y = pow(u_damp.y, v_coords.x * u_model_size.x);}
-        else if (u_damp.y < 0.0) {damp.y = pow((-1.0 * u_damp.y), (1.0 - v_coords.x) * u_model_size.x);}
-
-        if (u_direction < 2.0) {wave_offset.x = sin( u_wave_period.x * (v_coords.y + (u_shader_time * u_wave_speed.x))) * u_wave_amp.x * 0.01 * damp.x;}
-        else {wave_offset.x = 0.0;}
-        if (u_direction < 1.0 || u_direction >= 2.0) {wave_offset.y = sin( u_wave_period.y * (v_coords.x + (u_shader_time * u_wave_speed.y))) * u_wave_amp.y * 0.01 * damp.y;}
-        else {wave_offset.y = 0.0;}
-
-        if (u_melt >= 0.0){
-            if (u_melt < 2.0) {melt_offset.x = sin( u_melt_params_x.x * (v_coords.x + (u_shader_time * u_melt_params_x.z))) * u_melt_params_x.y * 0.01 * damp.x;}
-            else {melt_offset.x = 0.0;}
-            if (u_melt < 1.0 || u_melt >= 2.0) {melt_offset.y = sin( u_melt_params_y.x * (v_coords.y + (u_shader_time * u_melt_params_y.z))) * u_melt_params_y.y * 0.01 * damp.y;}
-            else {melt_offset.y = 0.0;}
+        wave_offset = vec2(0.0, 0.0);
+        melt_offset = vec2(0.0, 0.0);
+        double_offset = vec2(0.0, 0.0);
+        damp = vec2(1.0, 1.0);
+    """, fragment_307="""
+        new_color = texture2D(tex0, v_coords+wave_offset+melt_offset);
+    """)
+    renpy.register_shader("watt.wave.damp_x", variables=wave_variables,
+        fragment_301=""" // damp_x, two versions
+        if (u_damp.x >= 0.0 && u_damp.x != 1.0) {
+            damp.x = pow(u_damp.x, v_coords.y * u_model_size.y);
         }
-        new_pos.x = v_coords.x + wave_offset.x + melt_offset.x;
-        new_pos.y = v_coords.y + wave_offset.y + melt_offset.y;
-
-        new_color = texture2D(tex0,new_pos);
-
-        if (u_double < 0.0) {gl_FragColor = new_color;}
-        else{
-            if (u_double < 2.0) {double_offset.x = sin( u_double_params_x.x * (v_coords.y + (u_shader_time * u_double_params_x.z))) * u_double_params_x.y * -0.01 * damp.x;}
-            else {double_offset.x = 0.0;}
-            if (u_double < 1.0 || u_double >= 2.0) {double_offset.y = sin( u_double_params_y.x * (v_coords.x + (u_shader_time * u_double_params_y.z))) * u_double_params_y.y * -0.01 * damp.y;}
-            else {double_offset.y = 0.0;}
-            double_pos.x = v_coords.x + double_offset.x + melt_offset.x;
-            double_pos.y = v_coords.y + double_offset.y + melt_offset.y;
-            double_color = texture2D(tex0,double_pos);
-            gl_FragColor = mix(new_color, double_color, 0.5);
+        else if (u_damp.x < 0.0) {
+            damp.x = pow((-1.0 * u_damp.x), (1.0 - v_coords.y) * u_model_size.y);
         }
     """)
-
+    renpy.register_shader("watt.wave.damp_y", variables=wave_variables,
+        fragment_301=""" // damp_y, two versions
+        if (u_damp.y >= 0.0 && u_damp.y != 1.0) {
+            damp.y = pow(u_damp.y, v_coords.x * u_model_size.x);
+        }
+        else if (u_damp.y < 0.0) {
+            damp.y = pow((-1.0 * u_damp.y), (1.0 - v_coords.x) * u_model_size.x);
+        }
+    """)
+    renpy.register_shader("watt.wave.direction_x", variables=wave_variables,
+        fragment_303="""
+        wave_offset.x = sin( u_wave_period.x * (v_coords.y + (u_shader_time * u_wave_speed.x))) * u_wave_amp.x * 0.01 * damp.x;
+    """)
+    renpy.register_shader("watt.wave.direction_y", variables=wave_variables,
+        fragment_303="""
+        wave_offset.y = sin( u_wave_period.y * (v_coords.x + (u_shader_time * u_wave_speed.y))) * u_wave_amp.y * 0.01 * damp.y;
+    """)
+    renpy.register_shader("watt.wave.melt_x", variables=wave_variables,
+        fragment_305="""
+        melt_offset.x = sin( u_melt_params_x.x * (v_coords.x + (u_shader_time * u_melt_params_x.z))) * u_melt_params_x.y * 0.01 * damp.x;
+    """)
+    renpy.register_shader("watt.wave.melt_y", variables=wave_variables,
+        fragment_305="""
+        melt_offset.y = sin( u_melt_params_y.x * (v_coords.y + (u_shader_time * u_melt_params_y.z))) * u_melt_params_y.y * 0.01 * damp.y;
+    """)
+    renpy.register_shader("watt.wave.double_x", variables=wave_variables,
+        fragment_309="""
+        double_offset.x = sin( u_double_params_x.x * (v_coords.y + (u_shader_time * u_double_params_x.z))) * u_double_params_x.y * -0.01 * damp.x;
+    """)
+    renpy.register_shader("watt.wave.double_y", variables=wave_variables,
+        fragment_309="""
+        double_offset.y = sin( u_double_params_y.x * (v_coords.x + (u_shader_time * u_double_params_y.z))) * u_double_params_y.y * -0.01 * damp.y;
+    """)
+    renpy.register_shader("watt.wave.double_xy", variables=wave_variables,
+        fragment_310="""
+        vec4 double_color = texture2D(tex0, v_coords + double_offset + melt_offset);
+        gl_FragColor = mix(new_color, double_color, 0.5);
+    """)
+    renpy.register_shader("watt.wave.double_not", variables=wave_variables,
+        fragment_308="""
+        gl_FragColor = new_color;
+    """)
 
     def advance_shader_time(trans, st, at):
         trans.u_shader_time = at
@@ -117,7 +137,20 @@ init -1 python:
     # If you have another shader you would like to use, you may want to add a parameter to tell it
     # to just return after the __call__ function is run, setup the next shader, and
     # then just use 'function advance_shader_time` in the ATL to update time.
-    class WaveShader(object):
+    class WaveShader:
+        shaderlist = ["watt.wave.common",
+                      "watt.wave.damp_x",
+                      "watt.wave.damp_y",
+                      "watt.wave.direction_x",
+                      "watt.wave.direction_y",
+                      "watt.wave.melt_x",
+                      "watt.wave.melt_y",
+                      "watt.wave.double_x",
+                      "watt.wave.double_y",
+                      "watt.wave.double_xy",
+                      "watt.wave.double_not",
+                      ]
+
         # All tuples (except for repeat) are sets of floats. The number specifies how many should be in the tuple.
         # STANDARD WAVE PARAMETERS
         # Note: For the following parameters, if a 2-tuple is supplied, the first element will affect the horizontal wave, the second will affect the vertical wave.
@@ -147,10 +180,33 @@ init -1 python:
         #                                        "mirror"/"mirrored" will have mirrored copies of the texture to infinity.
         #                                        A tuple, ie ("clamp", "repeat") will set the x behavior to clamping and y behavior to repeating. A single string will set it to the same value for both directions
         #                                        If omitted, the shader will inherit this property from the global state of OpenGL.
-        def __init__(self, amp = 12.0, period = 20.0, speed = 1.0, direction = "both", damp = 1.0, double=None, double_params=None, melt=None, melt_params=None, repeat=None):
-            # In Renpy's shaders, we don't have access to bools or ints. Only floats. So I use these in the shader to differentiate what waves should be included.
-            options_dict = {"vertical": 2.0, "y": 2.0, "horizontal": 1.0, "x": 1.0, "both": 0.0, None: -1.0}
-            property_dict = {'clamp': GL_CLAMP_TO_EDGE, 'mirrored': GL_MIRRORED_REPEAT, 'mirror': GL_MIRRORED_REPEAT, 'repeat': GL_REPEAT}
+        def __init__(self, amp=12.0,
+                           period=20.0,
+                           speed=1.0,
+                           direction="both",
+                           damp=1.0,
+                           double=None,
+                           double_params=None,
+                           melt=None,
+                           melt_params=None,
+                           repeat=None):
+            shaderlist = {"watt.wave.common",
+                          "watt.wave.damp_x",
+                          "watt.wave.damp_y",
+                          }
+
+            options_dict = {"vertical": ('y',),
+                            "y": ('y',),
+                            "horizontal": ('x',),
+                            "x": ('x',),
+                            "both": ('x', 'y',),
+                            "none": (),
+                            }
+            repeat_dict = {'clamp': GL_CLAMP_TO_EDGE,
+                             'mirrored': GL_MIRRORED_REPEAT,
+                             'mirror': GL_MIRRORED_REPEAT,
+                             'repeat': GL_REPEAT}
+
             # Helps make floats into 2-tuples or just gets a tuple if provided
             def float_or_tuple(param):
                 if isinstance(param, (float, int)):
@@ -160,86 +216,68 @@ init -1 python:
             self.period = float_or_tuple(period)
             self.amp = float_or_tuple(amp)
             self.speed = float_or_tuple(speed)
-            if direction in options_dict:
-                self.dir = options_dict[direction.lower()]
-            else:
-                self.dir = 0.0
+            shaderlist.update('watt.wave.direction_'+z for z in options_dict.get(str(direction).lower(), ('x', 'y')))
 
             self.damp = float_or_tuple(damp)
             # Additional effect parameters
-            if double is None:
-                self.double = -1.0
-                self.double_params_x = (0.0, 0.0, 0.0)
-                self.double_params_y = (0.0, 0.0, 0.0)
+            doubles = set(options_dict.get(str(double).lower(), ('x', 'y')))
+            if doubles:
+                doubles.add('xy')
             else:
-                if double in options_dict:
-                    self.double = options_dict[double.lower()]
+                doubles.add('not')
+            shaderlist.update('watt.wave.double_'+z for z in doubles)
+            if double_params is not None:
+                # Breaking up 3-tuples and 6-tuples
+                if len(double_params) == 6:
+                    self.double_params_x = double_params[0:3]
+                    self.double_params_y = double_params[3:]
                 else:
-                    self.double = 0.0
-                if double_params is not None:
-                    # Breaking up 3-tuples and 6-tuples
-                    if len(double_params) == 6:
-                        self.double_params_x = double_params[0:3]
-                        self.double_params_y = double_params[3:]
-                    else:
-                        self.double_params_x = double_params
-                        self.double_params_y = double_params
-                else:
-                    # Using the default period, amp and speed
-                    self.double_params_x = (self.period[0], self.amp[0], self.speed[0])
-                    self.double_params_y = (self.period[1], self.amp[1], self.speed[1])
+                    self.double_params_x = double_params
+                    self.double_params_y = double_params
+            else:
+                # Using the default period, amp and speed
+                self.double_params_x = (self.period[0], self.amp[0], self.speed[0])
+                self.double_params_y = (self.period[1], self.amp[1], self.speed[1])
 
-            if melt is None:
-                self.melt = -1.0
-                self.melt_params_x = (0.0, 0.0, 0.0)
-                self.melt_params_y = (0.0, 0.0, 0.0)
+            shaderlist.update('watt.wave.melt_'+z for z in options_dict.get(str(melt).lower(), ('x', 'y')))
+            if melt_params is not None:
+                # Breaking up 3-tuples and 6-tuples
+                if len(melt_params) == 6:
+                    self.melt_params_x = melt_params[0:3]
+                    self.melt_params_y = melt_params[3:]
+                else:
+                    self.melt_params_x = melt_params
+                    self.melt_params_y = melt_params
             else:
-                if melt in options_dict:
-                    self.melt = options_dict[melt.lower()]
-                else:
-                    self.melt = 0.0
-                if melt_params is not None:
-                    # Breaking up 3-tuples and 6-tuples
-                    if len(melt_params) == 6:
-                        self.melt_params_x = melt_params[0:3]
-                        self.melt_params_y = melt_params[3:]
-                    else:
-                        self.melt_params_x = melt_params
-                        self.melt_params_y = melt_params
-                else:
-                    # Using the default period, amp and speed
-                    self.melt_params_x = (self.period[0], self.amp[0], self.speed[0])
-                    self.melt_params_y = (self.period[1], self.amp[1], self.speed[1])
+                # Using the default period, amp and speed
+                self.melt_params_x = (self.period[0], self.amp[0], self.speed[0])
+                self.melt_params_y = (self.period[1], self.amp[1], self.speed[1])
             # Property parameters
             self.repeat = None
             if isinstance(repeat, (unicode,str)):
-                repeat = property_dict[repeat]
+                repeat = repeat_dict[repeat]
                 self.repeat = (repeat, repeat)
             elif isinstance(repeat, tuple):
-                self.repeat = (property_dict[repeat[0]], property_dict[repeat[1]])
+                self.repeat = (repeat_dict[repeat[0]], repeat_dict[repeat[1]])
 
             self.first_time = True
 
-        # Note on potential additions:
-        #   You can update the parameters over time if you'd like.
-        #   Such as u_wave_amp could be increased or decreased over time with some modifications.
+            self.shaderlist = shaderlist
+
         def __call__(self, trans, st, at):
-            if self.first_time or trans.shader != 'watt.wave':
-                trans.shader = 'watt.wave'
+            if self.first_time or set(trans.shader) != set(self.shaderlist):
+                trans.shader = self.shaderlist
                 trans.mesh = True
                 trans.u_shader_time = 0.0
                 trans.u_wave_period = self.period
                 trans.u_wave_amp = self.amp
                 trans.u_wave_speed = self.speed
-                trans.u_direction = self.dir
                 trans.u_damp = self.damp
-                trans.u_double = self.double
                 trans.u_double_params_x = self.double_params_x
                 trans.u_double_params_y = self.double_params_y
-                trans.u_melt = self.melt
                 trans.u_melt_params_x = self.melt_params_x
                 trans.u_melt_params_y = self.melt_params_y
-                if self.repeat != None:
+                if self.repeat is not None:
                     trans.gl_texture_wrap = self.repeat
                 self.first_time = False
             return advance_shader_time(trans, st, at)


### PR DESCRIPTION
- Each if/elif/else in the code has been removed, to save GPU performance
- the code within each if has been moved to a separate shader
- the code which used to set the variables the ifs were based upon, now toggle certain shaders based on the same conditions
- a shader list (a set actually) determines what operations will be performed or not performed. This is ascertained once, at init time (the init time of the WaveShader instance, not renpy's init time), instead of being tested for at each pixel's computation for each frame.

I didn't do the damp ones yet, because I'm not sure what to do with them. Should there be one damp_x+ and one damp_x-, or just one single damp_x testing the value of the damp parameter like it currently does ?
The fact that damp_x and damp_y need to be toggled makes no doubt to me, but the difference with melt, direction and double is that u_damp is not just a boolean flag, nor a vector of two boolean flags, rather its value is used in math. So, your thoughts ?